### PR TITLE
Remove $request param from buildForm()

### DIFF
--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -31,7 +31,7 @@ class SettingsForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, Request $request = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state) {
     // $custom_design_config = $this->config('custom_design.settings');
     $config = \Drupal::service('config.factory')->getEditable('custom_design.settings');
 


### PR DESCRIPTION
This param existing was making the AJAX upload on the file_managed field 500 error, which meant the form couldn't be submitted.